### PR TITLE
Fix conjugation highlighting not showing

### DIFF
--- a/bible_search_ui.py
+++ b/bible_search_ui.py
@@ -497,7 +497,8 @@ def format_for_display(word):
     return word.replace("_", " ")
 
 def highlight_verse(verse_text, search_term):
-    display_term = format_for_display(search_term)
+    # Normalize both verse text and the search term so Yeh variants match
+    display_term = normalize_pashto_char(format_for_display(search_term))
     style = "color:#ffd166; text-decoration: underline; font-weight:600; font-size:1.05em;"
     return re.sub(f'({re.escape(display_term)})', rf'<span style="{style}">\1</span>', normalize_pashto_char(verse_text), flags=re.IGNORECASE)
 


### PR DESCRIPTION
Normalize search term in `highlight_verse` to fix missing highlighting in conjugation sections.

Highlighting was missing because the verse text was normalized for display, but the search term was not, leading to mismatches (e.g., with Pashto Yeh variants) that prevented the regex from finding the target word.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bf63a93-cf31-4b9b-b2e6-aa1c47e0e5ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bf63a93-cf31-4b9b-b2e6-aa1c47e0e5ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

