### PR TITLE
Improve search term visibility behind tab

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -260,7 +260,7 @@ export default function Home() {
                   content: (
                     <div className="space-y-4">
                       {/* Search Section */}
-                      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 sm:p-4 bg-white dark:bg-gray-900 shadow-sm">
+                      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 sm:p-4 bg-white dark:bg-gray-900 shadow-sm mt-2">
                         <div className="flex flex-col space-y-4">
                           {/* Search Input Row */}
                           <div className="flex items-center gap-3">

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -45,7 +45,7 @@ export default function SearchBar({
           onChange={handleQueryChange}
           onKeyPress={handleKeyPress}
           placeholder="Search Pashto Bible (e.g., لیدل, خدا, موسى)"
-          className="w-full p-3 pr-12 border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full p-3 pr-16 pl-10 border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           dir="rtl"
           disabled={loading}
         />
@@ -55,7 +55,7 @@ export default function SearchBar({
         <button
           onClick={() => onSearch()}
           disabled={loading || !query.trim()}
-          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-3 py-1 bg-blue-500 text-white text-sm rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-3 py-1 bg-blue-500 text-white text-sm rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
         >
           {loading ? '...' : 'Search'}
         </button>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -22,7 +22,7 @@ export default function Tabs({ tabs, defaultTab, className = '' }: TabsProps) {
   return (
     <div className={`w-full ${className}`}>
       {/* Tab Headers */}
-      <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
+      <div className="flex border-b border-gray-200 dark:border-gray-700 mb-6">
         {tabs.map((tab) => (
           <button
             key={tab.id}
@@ -39,7 +39,7 @@ export default function Tabs({ tabs, defaultTab, className = '' }: TabsProps) {
       </div>
 
       {/* Tab Content */}
-      <div className="tab-content">
+      <div className="tab-content pt-2">
         {activeContent}
       </div>
     </div>


### PR DESCRIPTION
Adjust spacing and padding in the search UI to prevent the search input text from being hidden behind tab headers.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec7b5007-aab5-4c91-be55-39f33713ded0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec7b5007-aab5-4c91-be55-39f33713ded0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

