### PR TITLE
Improve search term visibility behind tab

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -38,24 +38,24 @@ export default function SearchBar({
 
   return (
     <div className="space-y-3">
-      <div className="relative">
+      <div className="relative z-10">
         <input
           type="text"
           value={query}
           onChange={handleQueryChange}
           onKeyPress={handleKeyPress}
           placeholder="Search Pashto Bible (e.g., لیدل, خدا, موسى)"
-          className="w-full p-3 pr-12 border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full p-3 pl-12 pr-20 sm:pr-24 border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           dir="rtl"
           disabled={loading}
         />
-        <div className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400">
+        <div className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 pointer-events-none">
           🔍
         </div>
         <button
           onClick={() => onSearch()}
           disabled={loading || !query.trim()}
-          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-3 py-1 bg-blue-500 text-white text-sm rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-2 sm:px-3 py-1 bg-blue-500 text-white text-xs sm:text-sm rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors z-20"
         >
           {loading ? '...' : 'Search'}
         </button>


### PR DESCRIPTION
Increase search input padding and adjust button positioning to prevent typed text from being hidden in RTL layout.

The search input uses `dir="rtl"`, which caused long search queries to be obscured by the search button positioned on the right. This PR increases the right padding of the input and adjusts the button's responsive sizing and z-index to ensure typed text remains fully visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc9748f2-7e7a-41ee-b509-37367bb80b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc9748f2-7e7a-41ee-b509-37367bb80b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

