### PR TITLE
Debug include related forms functionality

### DIFF
--- a/app/api/search_phrase/route.ts
+++ b/app/api/search_phrase/route.ts
@@ -2087,17 +2087,17 @@ export async function POST(request: NextRequest) {
           try {
             const { data: occurrenceData } = await supabase
               .from('form_occurrences')
-              .select('form, frequency')
-              .in('form', batch)
+              .select('pashto_form, frequency')
+              .in('pashto_form', batch)
               .gte('frequency', 1)
               .order('frequency', { ascending: false })
               .limit(30)
 
             if (Array.isArray(occurrenceData)) {
               for (const row of occurrenceData) {
-                if (row?.form && row?.frequency) {
+                if (row?.pashto_form && row?.frequency) {
                   existingForms.push({
-                    form: row.form,
+                    form: row.pashto_form,
                     count: Number(row.frequency) || 0
                   })
                 }
@@ -2108,18 +2108,18 @@ export async function POST(request: NextRequest) {
             try {
               const { data: occurrenceData2 } = await supabase
                 .from('form_occurrences')
-                .select('pashto_form, occurrence_count')
+                .select('pashto_form, frequency')
                 .in('pashto_form', batch)
-                .gte('occurrence_count', 1)
-                .order('occurrence_count', { ascending: false })
+                .gte('frequency', 1)
+                .order('frequency', { ascending: false })
                 .limit(30)
 
               if (Array.isArray(occurrenceData2)) {
                 for (const row of occurrenceData2) {
-                  if (row?.pashto_form && row?.occurrence_count) {
+                  if (row?.pashto_form && row?.frequency) {
                     existingForms.push({
                       form: row.pashto_form,
-                      count: Number(row.occurrence_count) || 0
+                      count: Number(row.frequency) || 0
                     })
                   }
                 }


### PR DESCRIPTION
Fix 'Include related forms' functionality by correcting column names in Supabase queries.

The API was attempting to query `form_occurrences` using `form` and `occurrence_count` columns, which do not exist in the database schema. This PR updates the queries to use the correct `pashto_form` and `frequency` columns, resolving the issue where related forms were not being retrieved.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f1c890e-2863-45c3-b839-ed89594d28a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f1c890e-2863-45c3-b839-ed89594d28a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

